### PR TITLE
Fix: filled autofill inputs

### DIFF
--- a/src/components/input/input.styles.ts
+++ b/src/components/input/input.styles.ts
@@ -117,6 +117,13 @@ export default css`
     -webkit-text-fill-color: var(--sl-color-primary-500);
   }
 
+  .input--filled .input__control:-webkit-autofill,
+  .input--filled .input__control:-webkit-autofill:hover,
+  .input--filled .input__control:-webkit-autofill:focus,
+  .input--filled .input__control:-webkit-autofill:active {
+    box-shadow: 0 0 0 var(--sl-input-height-large) var(--sl-input-filled-background-color) inset !important;
+  }
+
   .input__control::placeholder {
     color: var(--sl-input-placeholder-color);
     user-select: none;

--- a/src/components/input/input.styles.ts
+++ b/src/components/input/input.styles.ts
@@ -115,6 +115,7 @@ export default css`
   .input__control:-webkit-autofill:active {
     box-shadow: 0 0 0 var(--sl-input-height-large) var(--sl-input-background-color-hover) inset !important;
     -webkit-text-fill-color: var(--sl-color-primary-500);
+    caret-color: var(--sl-input-color);
   }
 
   .input--filled .input__control:-webkit-autofill,


### PR DESCRIPTION
- Fixes an issue with `<sl-input filled>` where autofilling in webkit browsers resulted in different background colors.

Repro: https://codepen.io/tomitheninja/pen/LYzBqZr?editors=1100

I believe the more specific `!important` will override the previous `!important`